### PR TITLE
Add Sanwo — universal payment SDK (multi-provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ This repository is organized for regional discovery:
 - SDK (PHP) - [Zepson-Technologies/dpo-php](https://github.com/Zepson-Technologies/dpo-php) (`community`)
 - SDK (Laravel) - [Zepson-Technologies/dpo-laravel](https://github.com/Zepson-Technologies/dpo-laravel) (`community`)
 
+#### Sanwo
+- Universal SDK (TypeScript/JS) - [Sanwohq/core](https://github.com/Sanwohq/core) (`community`)
+- SDK (React) - [@sanwohq/react](https://www.npmjs.com/package/@sanwohq/react) (`community`)
+- SDK (Vue) - [@sanwohq/vue](https://www.npmjs.com/package/@sanwohq/vue) (`community`)
+- SDK (Svelte) - [@sanwohq/svelte](https://www.npmjs.com/package/@sanwohq/svelte) (`community`)
+- SDK (React Native) - [Sanwohq/react-native](https://github.com/Sanwohq/react-native) (`community`)
+- SDK (Flutter) - [Sanwohq/flutter](https://github.com/Sanwohq/flutter) (`community`)
+- SDK (iOS/Swift) - [Sanwohq/ios](https://github.com/Sanwohq/ios) (`community`)
+- SDK (Android/Kotlin) - [Sanwohq/android](https://github.com/Sanwohq/android) (`community`)
+- Plugin (Shopify) - [Sanwohq/shopify](https://github.com/Sanwohq/shopify) (`community`)
+- Plugin (WordPress) - [Sanwohq/wordpress](https://github.com/Sanwohq/wordpress) (`community`)
+
 ## Maintainer Labels
 
 - `official`: Maintained by the payment provider or vendor organization.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository is organized for regional discovery:
 - SDK (Laravel) - [Zepson-Technologies/dpo-laravel](https://github.com/Zepson-Technologies/dpo-laravel) (`community`)
 
 #### Sanwo
-- Universal SDK (TypeScript/JS) - [Sanwohq/core](https://github.com/Sanwohq/core) (`community`)
+- Universal SDK (TypeScript/JS) - [Sanwohq](https://github.com/Sanwohq) (`community`)
 - SDK (React) - [@sanwohq/react](https://www.npmjs.com/package/@sanwohq/react) (`community`)
 - SDK (Vue) - [@sanwohq/vue](https://www.npmjs.com/package/@sanwohq/vue) (`community`)
 - SDK (Svelte) - [@sanwohq/svelte](https://www.npmjs.com/package/@sanwohq/svelte) (`community`)

--- a/data/sdk/sanwo.yml
+++ b/data/sdk/sanwo.yml
@@ -1,0 +1,48 @@
+id: sanwo
+entity_type: sdk
+category: sdk
+name: Sanwo
+provider: Multi-provider (Paystack, Flutterwave, Razorpay, Monnify, Interswitch)
+region: Pan-African / Global
+countries:
+  - Nigeria
+  - Ghana
+  - South Africa
+  - Kenya
+  - India
+languages:
+  - TypeScript
+  - JavaScript
+  - Dart
+  - Swift
+  - Kotlin
+integration_types:
+  - SDK
+  - Hosted Checkout
+  - Plugin
+maintainer_type: community
+repo_url: https://github.com/Sanwohq
+docs_url: https://docs.sanwo.dev
+website_url: https://sanwo.dev
+status: active
+notes: >-
+  Universal payment SDK — one interface for every payment provider.
+  Native SDKs for Web, React, Vue, Svelte, React Native, Flutter, iOS, and Android.
+  No-code integrations for Shopify, WordPress, Webflow, Wix, and Squarespace.
+  Supports custom provider templates.
+tags:
+  - universal
+  - multi-provider
+  - paystack
+  - flutterwave
+  - razorpay
+  - monnify
+  - interswitch
+  - react
+  - react-native
+  - flutter
+  - ios
+  - android
+  - shopify
+  - wordpress
+  - open-source


### PR DESCRIPTION
## Summary

Adds [Sanwo](https://github.com/Sanwohq) to the Regional / Pan-African section.

Sanwo is an open-source universal payment SDK that wraps multiple African and global payment providers (Paystack, Flutterwave, Razorpay, Monnify, Interswitch) behind one unified API. It also supports custom provider templates for any payment gateway.

**Platforms covered:**
- Web (vanilla JS, React, Vue, Svelte, Angular)
- Mobile (React Native, Flutter, iOS/Swift, Android/Kotlin)
- No-code (Shopify, WordPress, Webflow, Wix, Squarespace)

**This PR includes:**
- README entry under Regional / Pan-African → Sanwo
- YAML data record at `data/sdk/sanwo.yml`

**Links:**
- GitHub: https://github.com/Sanwohq
- Docs: https://docs.sanwo.dev
- npm: https://www.npmjs.com/org/sanwohq
- License: Apache-2.0